### PR TITLE
Support mirth 3 12 0

### DIFF
--- a/basicssl/.gitignore
+++ b/basicssl/.gitignore
@@ -7,3 +7,5 @@ build
 .project
 .settings
 lib
+*.DS_Store
+.idea

--- a/basicssl/build.gradle
+++ b/basicssl/build.gradle
@@ -14,7 +14,7 @@ plugins {
 }
 
 allprojects { 
-    version = '1.2';
+    version = '1.2'
 
     repositories {
         jcenter()

--- a/basicssl/build.gradle
+++ b/basicssl/build.gradle
@@ -80,7 +80,7 @@ task generatePluginXml {
 
             xml.pluginMetaData(path: rootProject.name) {
                 name('Basic SSL Extensions')
-                author('Alessandro Piroddi')
+                author('Tony Germano')
                 pluginVersion(version)
                 mirthVersion('3.12.0,3.8.1,3.8.0,3.7.1,3.7.0, 3.6.2, 3.6.1, 3.6.0, 3.5.2, 3.5.1, 3.5.0, 3.4.2, 3.4.1, 3.4.0')
                 url('https://github.com/tonygermano/connect-plugins')

--- a/basicssl/build.gradle
+++ b/basicssl/build.gradle
@@ -1,6 +1,6 @@
 /*
  * Copyright Tony Germano
- * Copyright Alessandro Piroddi
+ * Modified work Copyright Alessandro Piroddi
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/basicssl/build.gradle
+++ b/basicssl/build.gradle
@@ -1,6 +1,7 @@
 /*
  * Copyright Tony Germano
- * 
+ * Copyright Alessandro Piroddi
+ *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. 
@@ -13,7 +14,7 @@ plugins {
 }
 
 allprojects { 
-    version = '1.1';
+    version = '1.2';
 
     repositories {
         jcenter()
@@ -53,16 +54,24 @@ task stageLibs(type: Copy) {
 task generatePluginXml {
     dependsOn stageLibs
     doLast {
+        def coreProject = findProject(':core')
         def serverProject = findProject(':server')
         def sharedProject = findProject(':shared')
         def clientProject = findProject(':client')
+        def coreLibraries = coreProject ? coreProject.configurations.runtimeClasspath.collect { it.name } : []
         def serverLibraries = serverProject ? serverProject.configurations.runtimeClasspath.collect { it.name } : []
         def sharedLibraries = sharedProject ? sharedProject.configurations.runtimeClasspath.collect { it.name } : []
         def clientLibraries = clientProject ? clientLibraries.configurations.runtimeClasspath.collect { it.name } : []
 
-        sharedLibraries = (sharedLibraries + serverLibraries.intersect(clientLibraries)).unique()
+        sharedLibraries = (
+                sharedLibraries +
+                serverLibraries.intersect(clientLibraries) +
+                serverLibraries.intersect(coreLibraries) +
+                coreLibraries.intersect(clientLibraries)
+        ).unique()
         clientLibraries = clientLibraries - sharedLibraries
         serverLibraries = serverLibraries - sharedLibraries
+        coreLibraries = coreLibraries - sharedLibraries
 
         file("$buildDir/staging/$rootProject.name/plugin.xml").withWriter { writer ->
             // Create MarkupBuilder with 8 space indent
@@ -70,10 +79,10 @@ task generatePluginXml {
             xml.doubleQuotes = true
 
             xml.pluginMetaData(path: rootProject.name) {
-                name('Basic SSL Extentions')
-                author('Tony Germano')
+                name('Basic SSL Extensions')
+                author('Alessandro Piroddi')
                 pluginVersion(version)
-                mirthVersion('3.8.1,3.8.0,3.7.1,3.7.0, 3.6.2, 3.6.1, 3.6.0, 3.5.2, 3.5.1, 3.5.0, 3.4.2, 3.4.1, 3.4.0')
+                mirthVersion('3.12.0,3.8.1,3.8.0,3.7.1,3.7.0, 3.6.2, 3.6.1, 3.6.0, 3.5.2, 3.5.1, 3.5.0, 3.4.2, 3.4.1, 3.4.0')
                 url('https://github.com/tonygermano/connect-plugins')
                 description('This plugin provides basic SSL support')
                 serverClasses {
@@ -82,6 +91,9 @@ task generatePluginXml {
                     }
                 }
                 library(type: 'SERVER', path: serverProject.jar.outputs.files.singleFile.name)
+                coreLibraries.each {lib ->
+                    library(type: 'CORE', path: "lib/$lib")
+                }
                 serverLibraries.each {lib ->
                     library(type: 'SERVER', path: "lib/$lib")
                 }

--- a/basicssl/server/build.gradle
+++ b/basicssl/server/build.gradle
@@ -1,6 +1,7 @@
 /*
  * Copyright Tony Germano
- * 
+ * Copyright Alessandro Piroddi
+ *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. 
@@ -8,15 +9,16 @@
 
 dependencies {
     // Mirth libraries
-    compileOnly files('lib/mirth-server.jar', 'lib/donkey-server.jar', 'lib/http-server.jar', 'lib/http-shared.jar')
-    testImplementation files('lib/mirth-server.jar', 'lib/donkey-server.jar', 'lib/http-server.jar', 'lib/http-shared.jar')
+    compileOnly files('lib/mirth-client-core.jar', 'lib/mirth-server.jar', 'lib/donkey-server.jar', 'lib/http-server.jar', 'lib/http-shared.jar')
+    testImplementation files('lib/mirth-client-core.jar', 'lib/mirth-server.jar', 'lib/donkey-server.jar', 'lib/http-server.jar', 'lib/http-shared.jar')
 
     // Mirth provided libraries
     [
         'javax.servlet:javax.servlet-api:3.1.0',
         'org.apache.httpcomponents:httpclient:4.5.1',
-        'org.eclipse.jetty:jetty-server:9.4.9.v20180320',
-        'commons-configuration:commons-configuration:1.7'
+        'org.eclipse.jetty:jetty-server:9.4.44.v20210927',
+        'org.apache.commons:commons-configuration2:2.7'
+
     ].each { lib -> 
         compileOnly lib
         testImplementation lib

--- a/basicssl/server/build.gradle
+++ b/basicssl/server/build.gradle
@@ -1,6 +1,6 @@
 /*
  * Copyright Tony Germano
- * Copyright Alessandro Piroddi
+ * Modified work Copyright Alessandro Piroddi
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/basicssl/server/src/main/kotlin/io/github/tonygermano/connect/plugins/basicssl/BasicHttpsConfiguration.kt
+++ b/basicssl/server/src/main/kotlin/io/github/tonygermano/connect/plugins/basicssl/BasicHttpsConfiguration.kt
@@ -2,7 +2,8 @@
  * Original work Copyright (c) Mirth Corporation. All rights reserved. http://www.mirthcorp.com
  * 
  * Modified work Copyright 2019 Tony Germano
- * 
+ * Modified work Copyright 2022 Alessandro Piroddi
+ *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. 
@@ -11,11 +12,11 @@
  * defined by the Mozilla Public License, v. 2.0.
  * 
  * This file is derived from the following files:
- * https://github.com/nextgenhealthcare/connect/blob/3.8.1/server/src/com/mirth/connect/connectors/http/DefaultHttpConfiguration.java
- * https://github.com/nextgenhealthcare/connect/blob/3.8.1/server/src/com/mirth/connect/server/MirthWebServer.java
+ * https://github.com/nextgenhealthcare/connect/blob/3.12.0/server/src/com/mirth/connect/connectors/http/DefaultHttpConfiguration.java
+ * https://github.com/nextgenhealthcare/connect/blob/3.12.0/server/src/com/mirth/connect/server/MirthWebServer.java
  */
 
-package io.github.tonygermano.connect.plugins.basicssl;
+package io.github.tonygermano.connect.plugins.basicssl
 
 import com.mirth.connect.client.core.PropertiesConfigurationUtil
 import com.mirth.connect.connectors.http.HttpConfiguration
@@ -43,13 +44,14 @@ import java.io.InputStream
 import java.security.KeyStore
 import javax.servlet.ServletRequest
 
+@SuppressWarnings("unused")
 class BasicHttpsConfiguration : HttpConfiguration {
 
-    private val configurationController = ControllerFactory.getFactory().createConfigurationController();
+    private val configurationController = ControllerFactory.getFactory().createConfigurationController()
 
     override fun configureConnectorDeploy(connector: Connector) {
         if (connector is HttpDispatcher) {
-            configureSocketFactoryRegistry(null, connector.getSocketFactoryRegistry());
+            configureSocketFactoryRegistry(null, connector.socketFactoryRegistry)
         }
     }
 
@@ -58,60 +60,71 @@ class BasicHttpsConfiguration : HttpConfiguration {
     override fun configureReceiver(connector: HttpReceiver) {
 
 
-        val mirthProperties = getMirthProperties();
+        val mirthProperties = getMirthProperties()
 
-        val keyStore = KeyStore.getInstance("JCEKS");
-        File(mirthProperties.getString("keystore.path")).inputStream().use() {
-            keyStore.load(it, mirthProperties.getString("keystore.storepass").toCharArray());
+        val keyStore = KeyStore.getInstance("JCEKS")
+        File(mirthProperties.getString("keystore.path")).inputStream().use {
+            keyStore.load(it, mirthProperties.getString("keystore.storepass").toCharArray())
         }
 
-        val contextFactory = SslContextFactory();
-        contextFactory.setKeyStore(keyStore);
-        contextFactory.setCertAlias("mirthconnect");
-        contextFactory.setKeyManagerPassword(mirthProperties.getString("keystore.keypass"));
+        val contextFactory = SslContextFactory()
+        contextFactory.keyStore = keyStore
+        contextFactory.certAlias = "mirthconnect"
+        contextFactory.setKeyManagerPassword(mirthProperties.getString("keystore.keypass"))
+        contextFactory.endpointIdentificationAlgorithm = null
 
-        val config = org.eclipse.jetty.server.HttpConfiguration();
-        config.setSecureScheme("https");
-        config.setSecurePort(mirthProperties.getInt("https.port"));
-        config.addCustomizer(SecureRequestCustomizer());
-        config.setSendServerVersion(false);
-        config.setSendXPoweredBy(false);
+
+        val config = org.eclipse.jetty.server.HttpConfiguration()
+        config.secureScheme = "https"
+        config.securePort = mirthProperties.getInt("https.port")
+        config.addCustomizer(SecureRequestCustomizer())
+        config.sendServerVersion = false
+        config.sendXPoweredBy = false
 
         val sslConnector = ServerConnector(
-            connector.getServer(),
+            connector.server,
             SslConnectionFactory(contextFactory, HttpVersion.HTTP_1_1.asString()),
             HttpConnectionFactory(config)
-        );
+        )
 
-        sslConnector.setName("ssllistener");
-        sslConnector.setHost(connector.getHost());
-        sslConnector.setPort(connector.getPort());
-        sslConnector.setIdleTimeout(connector.getTimeout().toLong());
-        connector.getServer().addConnector(sslConnector);
+        sslConnector.name = "ssllistener"
+        sslConnector.host = connector.host
+        sslConnector.port = connector.port
+        sslConnector.idleTimeout = connector.timeout.toLong()
+        connector.server.addConnector(sslConnector)
 
-        val lowResourceMonitor = LowResourceMonitor(connector.getServer());
-        lowResourceMonitor.setMonitoredConnectors(listOf(sslConnector));
+        val lowResourceMonitor = LowResourceMonitor(connector.server)
+        lowResourceMonitor.monitoredConnectors = listOf(sslConnector)
         // If the number of connections open reaches 200
-        lowResourceMonitor.setMaxConnections(200);
+        lowResourceMonitor.maxConnections = 200
         // Then close connections after 200 seconds, which is the default MaxIdleTime value. This should affect existing connections as well.
-        lowResourceMonitor.setLowResourcesIdleTimeout(200000);
+        lowResourceMonitor.lowResourcesIdleTimeout = 200000
 
-        contextFactory.setExcludeProtocols();
-        contextFactory.setExcludeCipherSuites();
-        contextFactory.setIncludeProtocols(*MirthSSLUtil.getEnabledHttpsProtocols(configurationController.getHttpsServerProtocols()));
-        contextFactory.setIncludeCipherSuites(*MirthSSLUtil.getEnabledHttpsCipherSuites(configurationController.getHttpsCipherSuites()));
+        contextFactory.setExcludeProtocols()
+        contextFactory.setExcludeCipherSuites()
+        contextFactory.setIncludeProtocols(*MirthSSLUtil.getEnabledHttpsProtocols(configurationController.httpsServerProtocols))
+        contextFactory.setIncludeCipherSuites(*MirthSSLUtil.getEnabledHttpsCipherSuites(configurationController.httpsCipherSuites))
     }
 
-    override fun configureDispatcher(connector: HttpDispatcher, connectorProperties: HttpDispatcherProperties)  {}
+    override fun configureDispatcher(connector: HttpDispatcher, connectorProperties: HttpDispatcherProperties) {}
 
-    override fun configureSocketFactoryRegistry(properties: ConnectorPluginProperties?, registry: RegistryBuilder<ConnectionSocketFactory>) {
-        val enabledProtocols = MirthSSLUtil.getEnabledHttpsProtocols(configurationController.getHttpsClientProtocols());
-        val enabledCipherSuites = MirthSSLUtil.getEnabledHttpsCipherSuites(configurationController.getHttpsCipherSuites());
-        val sslConnectionSocketFactory = SSLConnectionSocketFactory(SSLContexts.createSystemDefault(), enabledProtocols, enabledCipherSuites, NoopHostnameVerifier.INSTANCE);
-        registry.register("https", sslConnectionSocketFactory);
+    override fun configureSocketFactoryRegistry(
+        properties: ConnectorPluginProperties?,
+        registry: RegistryBuilder<ConnectionSocketFactory>
+    ) {
+        val enabledProtocols = MirthSSLUtil.getEnabledHttpsProtocols(configurationController.httpsClientProtocols)
+        val enabledCipherSuites =
+            MirthSSLUtil.getEnabledHttpsCipherSuites(configurationController.httpsCipherSuites)
+        val sslConnectionSocketFactory = SSLConnectionSocketFactory(
+            SSLContexts.createSystemDefault(),
+            enabledProtocols,
+            enabledCipherSuites,
+            NoopHostnameVerifier.INSTANCE
+        )
+        registry.register("https", sslConnectionSocketFactory)
     }
 
-    override fun getRequestInformation(request: ServletRequest): Map<String, Any> = emptyMap<String, Any>();
+    override fun getRequestInformation(request: ServletRequest): Map<String, Any> = emptyMap<String, Any>()
 
     @Throws(FileNotFoundException::class, ConfigurationException::class)
     private fun getMirthProperties(): PropertiesConfiguration {

--- a/basicssl/server/src/main/kotlin/io/github/tonygermano/connect/plugins/basicssl/BasicSslPlugin.kt
+++ b/basicssl/server/src/main/kotlin/io/github/tonygermano/connect/plugins/basicssl/BasicSslPlugin.kt
@@ -1,28 +1,31 @@
 /*
  * Copyright Tony Germano
- * 
+ *
+ * Modified work Copyright 2022 Alessandro Piroddi
+ *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. 
  */
 
- package io.github.tonygermano.connect.plugins.basicssl;
+ package io.github.tonygermano.connect.plugins.basicssl
 
-import com.mirth.connect.model.ExtensionPermission;
-import com.mirth.connect.plugins.ServicePlugin;
-import com.mirth.connect.server.controllers.ControllerFactory;
-import java.util.Properties;
+import com.mirth.connect.model.ExtensionPermission
+import com.mirth.connect.plugins.ServicePlugin
+import com.mirth.connect.server.controllers.ControllerFactory
+import java.util.Properties
 
 /**
  * This plugin registers BasicHttpsConfiguration so that the HTTP Listener will pick it up
  * 
  * @author Tony Germano
  */
+@SuppressWarnings("unused")
 class BasicSslPlugin : ServicePlugin {
 
-    private val configurationController = ControllerFactory.getFactory().createConfigurationController();
+    private val configurationController = ControllerFactory.getFactory().createConfigurationController()
 
-    override fun getPluginPointName() = "Basic SSL";
+    override fun getPluginPointName() = "Basic SSL"
 
     override fun start() {}
 
@@ -30,14 +33,14 @@ class BasicSslPlugin : ServicePlugin {
 
     override fun init(properties: Properties) {
         configurationController.saveProperty("HTTP", "httpConfigurationClass",
-            "io.github.tonygermano.connect.plugins.basicssl.BasicHttpsConfiguration");
+            "io.github.tonygermano.connect.plugins.basicssl.BasicHttpsConfiguration")
     }
 
     override fun update(properties: Properties) {}
 
-    override fun getDefaultProperties(): Properties = Properties();
+    override fun getDefaultProperties(): Properties = Properties()
 
-    override fun getExtensionPermissions(): Array<ExtensionPermission>? = null;
+    override fun getExtensionPermissions(): Array<ExtensionPermission>? = null
 
     override fun getObjectsForSwaggerExamples(): MutableMap<String, Any> {
         TODO("Not yet implemented")

--- a/basicssl/server/src/main/kotlin/io/github/tonygermano/connect/plugins/basicssl/BasicSslPlugin.kt
+++ b/basicssl/server/src/main/kotlin/io/github/tonygermano/connect/plugins/basicssl/BasicSslPlugin.kt
@@ -38,4 +38,8 @@ class BasicSslPlugin : ServicePlugin {
     override fun getDefaultProperties(): Properties = Properties();
 
     override fun getExtensionPermissions(): Array<ExtensionPermission>? = null;
+
+    override fun getObjectsForSwaggerExamples(): MutableMap<String, Any> {
+        TODO("Not yet implemented")
+    }
 }


### PR DESCRIPTION
Minor refactoring that adds support for Mirth 3.12.0. The code has been updated with the most recent DefaultHttpConfiguration and MirthWebServer modifications (from source code).

The code has been refactored according to Kotlin syntax suggestions from IntellijIdea